### PR TITLE
DateTimeConfigurationChangeNotification moved to v8::Isolate

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "test": "tap test.js --cov"
   },
   "dependencies": {
-    "bindings": "~1.2.1",
-    "nan": "~2.3.3"
+    "bindings": "^1.2.1",
+    "nan": "^2.3.3"
   },
   "devDependencies": {
-    "node-gyp": "~3.0.3",
-    "tap": "~2.1.0"
+    "node-gyp": "^3.0.3",
+    "tap": "^14.11.0"
   },
   "license": "MIT",
   "author": "Evan Lucas <evanlucas@me.com>",

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -18,7 +18,7 @@ NAN_METHOD(Reset) {
 #else
   tzset();
 #endif
-  Date::DateTimeConfigurationChangeNotification(isolate);
+  isolate->DateTimeConfigurationChangeNotification(Isolate::TimeZoneDetection::kRedetect);
 }
 
 NAN_MODULE_INIT(Init) {

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ test('should be able to reset the timezone', function(t) {
   reset()
 
   var d2 = new Date('10/20/2015 8:50:00 AM UTC')
-  t.equal(d2.toString(), 'Mon Oct 19 2015 22:50:00 GMT-1000 (HST)')
+  t.equal(d2.toString(), 'Mon Oct 19 2015 22:50:00 GMT-1000 (Hawaii-Aleutian Standard Time)')
 
   delete process.env.TZ
 


### PR DESCRIPTION
@evanlucas 
As mentioned in #5 and [V8 no longer resets the timezone cache upon invoking v8::Date::DateTimeConfigurationChangeNotification](https://github.com/nodejs/node/issues/19974), I have provided fix and tested for Linux 5.8.0-44-generic #50~20.04.1-Ubuntu with following nodejs versions. Please review and accept PR.

- [Node v14.16.0 (LTS)](https://nodejs.org/en/blog/release/v14.16.0/)
- [Node v12.21.0 (LTS)](https://nodejs.org/en/blog/release/v12.21.0/)
In general it works for Node >=v12.x.x

Additionally modified test.js and package.json as needed.